### PR TITLE
Support using character and string literals

### DIFF
--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -17,6 +17,21 @@ where
     }
 }
 
+impl<'a> Parser<'a, char> for char {
+    fn parse(&self, input: &'a str) -> Result<(char, &'a str), Error> {
+        self::character::character(self).parse(input)
+    }
+}
+
+impl<'a, 'b> Parser<'a, &'b str> for &'b str
+where
+    'a: 'b,
+{
+    fn parse(&self, input: &'a str) -> Result<(&'b str, &'a str), Error> {
+        self::sequence::sequence(self).parse(input)
+    }
+}
+
 pub fn parse<'a, P, O>(input: &'a str, parser: P) -> Result<(O, &'a str), Error>
 where
     P: Parser<'a, O>,
@@ -84,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse() {
+    fn test_parser_struct() {
         assert_eq!(parse("", Custom), Err(Error::incomplete()));
 
         assert_eq!(parse("a", Custom), Err(Error::unexpected('a')));
@@ -92,6 +107,28 @@ mod tests {
         assert_eq!(parse("$", Custom), Ok(("$", "")));
 
         assert_eq!(parse("$$", Custom), Ok(("$", "$")));
+    }
+
+    #[test]
+    fn test_parser_char() {
+        assert_eq!(parse("", 'h'), Err(Error::incomplete()));
+        assert_eq!(parse("$", 'h'), Err(Error::unexpected('$')));
+        assert_eq!(parse("h", 'h'), Ok(('h', "")));
+        assert_eq!(parse("hello", 'h'), Ok(('h', "ello")));
+    }
+
+    #[test]
+    fn test_parser_str() {
+        assert_eq!(parse("", "h"), Err(Error::incomplete()));
+        assert_eq!(parse("$", "h"), Err(Error::unexpected('$')));
+        assert_eq!(parse("h", "h"), Ok(("h", "")));
+        assert_eq!(parse("hello", "h"), Ok(("h", "ello")));
+
+        assert_eq!(parse("", "hello"), Err(Error::incomplete()));
+        assert_eq!(parse("h", "hello"), Err(Error::incomplete()));
+        assert_eq!(parse("help", "hello"), Err(Error::unexpected('p')));
+        assert_eq!(parse("hello", "hello"), Ok(("hello", "")));
+        assert_eq!(parse("hello world", "hello"), Ok(("hello", " world")));
     }
 
     #[test]


### PR DESCRIPTION
This adds support for using character and string literals as parsers to allow matching of specific character sequences without wrapping them in a corresponding parser method.