### PR TITLE
Refactor character and sequence functionality

### DIFF
--- a/crates/brace-parser/src/character.rs
+++ b/crates/brace-parser/src/character.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use crate::{sequence, take, Error, Parser};
+use crate::{take, Error, Parser};
 
 pub fn character<'a, T>(ch: T) -> impl Parser<'a, char>
 where
@@ -13,48 +13,58 @@ where
     }
 }
 
-pub fn digit(input: &str) -> Result<(char, &str), Error> {
-    sequence::digit(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+pub fn decimal(input: &str) -> Result<(char, &str), Error> {
+    take(char::is_ascii_digit)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
-pub fn hexdigit(input: &str) -> Result<(char, &str), Error> {
-    sequence::hexdigit(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+pub fn hexadecimal(input: &str) -> Result<(char, &str), Error> {
+    take(char::is_ascii_hexdigit)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 pub fn alphabetic(input: &str) -> Result<(char, &str), Error> {
-    sequence::alphabetic(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+    take(char::is_ascii_alphabetic)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 pub fn alphanumeric(input: &str) -> Result<(char, &str), Error> {
-    sequence::alphanumeric(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+    take(char::is_ascii_alphanumeric)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 pub fn lowercase(input: &str) -> Result<(char, &str), Error> {
-    sequence::lowercase(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+    take(char::is_ascii_lowercase)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 pub fn uppercase(input: &str) -> Result<(char, &str), Error> {
-    sequence::uppercase(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
-}
-
-pub fn space(input: &str) -> Result<(char, &str), Error> {
-    sequence::space(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
-}
-
-pub fn tab(input: &str) -> Result<(char, &str), Error> {
-    sequence::tab(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+    take(char::is_ascii_uppercase)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 pub fn indent(input: &str) -> Result<(char, &str), Error> {
-    sequence::indent(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+    take(crate::util::is_ascii_indent)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 pub fn linebreak(input: &str) -> Result<(char, &str), Error> {
-    sequence::linebreak(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+    take(crate::util::is_ascii_linebreak)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 pub fn whitespace(input: &str) -> Result<(char, &str), Error> {
-    sequence::whitespace(input).and_then(|(out, rem)| Ok((out.chars().next().unwrap(), rem)))
+    take(char::is_ascii_whitespace)
+        .parse(input)
+        .map(|(out, rem)| (out.chars().next().unwrap(), rem))
 }
 
 #[cfg(test)]
@@ -72,129 +82,149 @@ mod tests {
     }
 
     #[test]
-    fn test_digit() {
+    fn test_decimal() {
         for ch in "0123456789".chars() {
-            assert_eq!(parse(&format!("{}", ch), digit), Ok((ch, "")));
+            assert_eq!(parse(&ch.to_string(), decimal), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), decimal), Ok((ch, "$")));
         }
 
-        assert_eq!(parse("", digit), Err(Error::incomplete()));
-        assert_eq!(parse("$", digit), Err(Error::unexpected('$')));
-        assert_eq!(parse("a", digit), Err(Error::unexpected('a')));
-        assert_eq!(parse("Z", digit), Err(Error::unexpected('Z')));
+        for ch in "$aZ\n".chars() {
+            assert_eq!(parse(&ch.to_string(), decimal), Err(Error::unexpected(ch)));
+        }
+
+        assert_eq!(parse("", decimal), Err(Error::incomplete()));
     }
 
     #[test]
     fn test_hexdigit() {
         for ch in "0123456789abcdefABCDEF".chars() {
-            assert_eq!(parse(&format!("{}", ch), hexdigit), Ok((ch, "")));
+            assert_eq!(parse(&ch.to_string(), hexadecimal), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), hexadecimal), Ok((ch, "$")));
         }
 
-        assert_eq!(parse("", hexdigit), Err(Error::incomplete()));
-        assert_eq!(parse("$", hexdigit), Err(Error::unexpected('$')));
-        assert_eq!(parse("g", hexdigit), Err(Error::unexpected('g')));
-        assert_eq!(parse("Z", hexdigit), Err(Error::unexpected('Z')));
+        for ch in "$gZ\n".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), hexadecimal),
+                Err(Error::unexpected(ch))
+            );
+        }
+
+        assert_eq!(parse("", hexadecimal), Err(Error::incomplete()));
     }
 
     #[test]
     fn test_alphabetic() {
         for ch in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
-            assert_eq!(parse(&format!("{}", ch), alphabetic), Ok((ch, "")));
+            assert_eq!(parse(&ch.to_string(), alphabetic), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), alphabetic), Ok((ch, "$")));
+        }
+
+        for ch in "$0 \n".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), alphabetic),
+                Err(Error::unexpected(ch))
+            );
         }
 
         assert_eq!(parse("", alphabetic), Err(Error::incomplete()));
-        assert_eq!(parse("$", alphabetic), Err(Error::unexpected('$')));
-        assert_eq!(parse("0", alphabetic), Err(Error::unexpected('0')));
     }
 
     #[test]
     fn test_alphanumeric() {
         for ch in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
-            assert_eq!(parse(&format!("{}", ch), alphanumeric), Ok((ch, "")));
+            assert_eq!(parse(&ch.to_string(), alphanumeric), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), alphanumeric), Ok((ch, "$")));
+        }
+
+        for ch in "$ \n".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), alphanumeric),
+                Err(Error::unexpected(ch))
+            );
         }
 
         assert_eq!(parse("", alphanumeric), Err(Error::incomplete()));
-        assert_eq!(parse("$", alphanumeric), Err(Error::unexpected('$')));
     }
 
     #[test]
     fn test_lowercase() {
         for ch in "abcdefghijklmnopqrstuvwxyz".chars() {
-            assert_eq!(parse(&format!("{}", ch), lowercase), Ok((ch, "")));
+            assert_eq!(parse(&ch.to_string(), lowercase), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), lowercase), Ok((ch, "$")));
         }
 
-        for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
+        for ch in "$ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), lowercase),
+                parse(&ch.to_string(), lowercase),
                 Err(Error::unexpected(ch))
             );
         }
 
         assert_eq!(parse("", lowercase), Err(Error::incomplete()));
-        assert_eq!(parse("$", lowercase), Err(Error::unexpected('$')));
     }
 
     #[test]
     fn test_uppercase() {
         for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
-            assert_eq!(parse(&format!("{}", ch), uppercase), Ok((ch, "")));
+            assert_eq!(parse(&ch.to_string(), uppercase), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), uppercase), Ok((ch, "$")));
         }
 
-        for ch in "abcdefghijklmnopqrstuvwxyz".chars() {
+        for ch in "$abcdefghijklmnopqrstuvwxyz".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), uppercase),
+                parse(&ch.to_string(), uppercase),
                 Err(Error::unexpected(ch))
             );
         }
 
         assert_eq!(parse("", uppercase), Err(Error::incomplete()));
-        assert_eq!(parse("$", uppercase), Err(Error::unexpected('$')));
-    }
-
-    #[test]
-    fn test_space() {
-        assert_eq!(parse("", space), Err(Error::incomplete()));
-        assert_eq!(parse("$", space), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", space), Err(Error::unexpected('\n')));
-        assert_eq!(parse("\t", space), Err(Error::unexpected('\t')));
-        assert_eq!(parse(" ", space), Ok((' ', "")));
-    }
-
-    #[test]
-    fn test_tab() {
-        assert_eq!(parse("", tab), Err(Error::incomplete()));
-        assert_eq!(parse("$", tab), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", tab), Err(Error::unexpected('\n')));
-        assert_eq!(parse(" ", tab), Err(Error::unexpected(' ')));
-        assert_eq!(parse("\t", tab), Ok(('\t', "")));
     }
 
     #[test]
     fn test_indent() {
+        for ch in " \t".chars() {
+            assert_eq!(parse(&ch.to_string(), indent), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), indent), Ok((ch, "$")));
+        }
+
+        for ch in "$\n".chars() {
+            assert_eq!(parse(&ch.to_string(), indent), Err(Error::unexpected(ch)));
+        }
+
         assert_eq!(parse("", indent), Err(Error::incomplete()));
-        assert_eq!(parse("$", indent), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", indent), Err(Error::unexpected('\n')));
-        assert_eq!(parse("\t", indent), Ok(('\t', "")));
-        assert_eq!(parse(" ", indent), Ok((' ', "")));
     }
 
     #[test]
     fn test_linebreak() {
+        for ch in "\n\r\u{000C}".chars() {
+            assert_eq!(parse(&ch.to_string(), linebreak), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), linebreak), Ok((ch, "$")));
+        }
+
+        for ch in "$ \t".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), linebreak),
+                Err(Error::unexpected(ch))
+            );
+        }
+
         assert_eq!(parse("", linebreak), Err(Error::incomplete()));
-        assert_eq!(parse("$", linebreak), Err(Error::unexpected('$')));
-        assert_eq!(parse(" ", linebreak), Err(Error::unexpected(' ')));
-        assert_eq!(parse("\t", linebreak), Err(Error::unexpected('\t')));
-        assert_eq!(parse("\r", linebreak), Ok(('\r', "")));
-        assert_eq!(parse("\u{000C}", linebreak), Ok(('\u{000C}', "")));
     }
 
     #[test]
     fn test_whitespace() {
+        for ch in " \t\n\t\u{000C}".chars() {
+            assert_eq!(parse(&ch.to_string(), whitespace), Ok((ch, "")));
+            assert_eq!(parse(&(ch.to_string() + "$"), whitespace), Ok((ch, "$")));
+        }
+
+        for ch in "$a".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), whitespace),
+                Err(Error::unexpected(ch))
+            );
+        }
+
         assert_eq!(parse("", whitespace), Err(Error::incomplete()));
-        assert_eq!(parse("$", whitespace), Err(Error::unexpected('$')));
-        assert_eq!(parse(" ", whitespace), Ok((' ', "")));
-        assert_eq!(parse("\t", whitespace), Ok(('\t', "")));
-        assert_eq!(parse("\n", whitespace), Ok(('\n', "")));
-        assert_eq!(parse("\r", whitespace), Ok(('\r', "")));
-        assert_eq!(parse("\u{000C}", whitespace), Ok(('\u{000C}', "")));
     }
 }

--- a/crates/brace-parser/src/combinator.rs
+++ b/crates/brace-parser/src/combinator.rs
@@ -51,7 +51,7 @@ pub fn trailing<'a, O, T>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sequence::{alphabetics, whitespaces};
+    use crate::sequence::{alphabetic, whitespace};
     use crate::{parse, Error};
 
     #[test]
@@ -107,14 +107,14 @@ mod tests {
         assert_eq!(
             parse(
                 "hello \n world",
-                pair("hello", pair(whitespaces, alphabetics))
+                pair("hello", pair(whitespace, alphabetic))
             ),
             Ok((("hello", (" \n ", "world")), ""))
         );
         assert_eq!(
             parse(
                 "hello \n universe",
-                pair("hello", pair(whitespaces, alphabetics))
+                pair("hello", pair(whitespace, alphabetic))
             ),
             Ok((("hello", (" \n ", "universe")), ""))
         );
@@ -143,11 +143,11 @@ mod tests {
             Err(Error::unexpected('g'))
         );
         assert_eq!(
-            parse("hello \n world", trio("hello", whitespaces, alphabetics)),
+            parse("hello \n world", trio("hello", whitespace, alphabetic)),
             Ok((("hello", " \n ", "world"), ""))
         );
         assert_eq!(
-            parse("hello \n universe", trio("hello", whitespaces, alphabetics)),
+            parse("hello \n universe", trio("hello", whitespace, alphabetic)),
             Ok((("hello", " \n ", "universe"), ""))
         );
     }

--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -4,6 +4,7 @@ pub mod character;
 pub mod combinator;
 pub mod error;
 pub mod sequence;
+pub mod util;
 
 pub trait Parser<'a, O> {
     fn parse(&self, input: &'a str) -> Result<(O, &'a str), Error>;

--- a/crates/brace-parser/src/sequence.rs
+++ b/crates/brace-parser/src/sequence.rs
@@ -1,112 +1,63 @@
-use crate::{take, take_while, Error, Parser};
+use crate::{take_while, Error, Parser};
 
-pub fn sequence<'a, 'b>(sequence: &'b str) -> impl Parser<'a, &'b str>
+pub fn sequence<'a, T>(sequence: T) -> impl Parser<'a, &'a str>
 where
-    'a: 'b,
+    T: AsRef<str>,
 {
-    move |mut input: &'a str| {
-        for ch in sequence.chars() {
-            match take(|character| character == &ch).parse(input) {
-                Ok((out, rem)) => {
-                    if out.chars().next().unwrap() == ch {
-                        input = rem;
+    move |input: &'a str| {
+        let mut iter = input.chars();
+        let mut pos = 0;
+
+        for ch in sequence.as_ref().chars() {
+            match iter.next() {
+                Some(character) => {
+                    if ch == character {
+                        pos += ch.len_utf8();
                     } else {
-                        return Err(Error::unexpected(ch));
+                        return Err(Error::unexpected(character));
                     }
                 }
-                Err(err) => return Err(err),
+                None => return Err(Error::incomplete()),
             }
         }
 
-        Ok((sequence, input))
+        Ok(input.split_at(pos))
     }
 }
 
-pub fn digit(input: &str) -> Result<(&str, &str), Error> {
-    take(char::is_ascii_digit).parse(input)
-}
-
-pub fn digits(input: &str) -> Result<(&str, &str), Error> {
+pub fn decimal(input: &str) -> Result<(&str, &str), Error> {
     take_while(char::is_ascii_digit).parse(input)
 }
 
-pub fn hexdigit(input: &str) -> Result<(&str, &str), Error> {
-    take(char::is_ascii_hexdigit).parse(input)
-}
-
-pub fn hexdigits(input: &str) -> Result<(&str, &str), Error> {
+pub fn hexadecimal(input: &str) -> Result<(&str, &str), Error> {
     take_while(char::is_ascii_hexdigit).parse(input)
 }
 
 pub fn alphabetic(input: &str) -> Result<(&str, &str), Error> {
-    take(char::is_ascii_alphabetic).parse(input)
-}
-
-pub fn alphabetics(input: &str) -> Result<(&str, &str), Error> {
     take_while(char::is_ascii_alphabetic).parse(input)
 }
 
 pub fn alphanumeric(input: &str) -> Result<(&str, &str), Error> {
-    take(char::is_ascii_alphanumeric).parse(input)
-}
-
-pub fn alphanumerics(input: &str) -> Result<(&str, &str), Error> {
     take_while(char::is_ascii_alphanumeric).parse(input)
 }
 
 pub fn lowercase(input: &str) -> Result<(&str, &str), Error> {
-    take(char::is_ascii_lowercase).parse(input)
-}
-
-pub fn lowercases(input: &str) -> Result<(&str, &str), Error> {
     take_while(char::is_ascii_lowercase).parse(input)
 }
 
 pub fn uppercase(input: &str) -> Result<(&str, &str), Error> {
-    take(char::is_ascii_uppercase).parse(input)
-}
-
-pub fn uppercases(input: &str) -> Result<(&str, &str), Error> {
     take_while(char::is_ascii_uppercase).parse(input)
 }
 
-pub fn space(input: &str) -> Result<(&str, &str), Error> {
-    take(|ch| ch == &' ').parse(input)
-}
-
-pub fn spaces(input: &str) -> Result<(&str, &str), Error> {
-    take_while(|ch| ch == &' ').parse(input)
-}
-
-pub fn tab(input: &str) -> Result<(&str, &str), Error> {
-    take(|ch| ch == &'\t').parse(input)
-}
-
-pub fn tabs(input: &str) -> Result<(&str, &str), Error> {
-    take_while(|ch| ch == &'\t').parse(input)
-}
-
 pub fn indent(input: &str) -> Result<(&str, &str), Error> {
-    take(|ch| ch == &' ' || ch == &'\t').parse(input)
-}
-
-pub fn indents(input: &str) -> Result<(&str, &str), Error> {
-    take_while(|ch| ch == &' ' || ch == &'\t').parse(input)
+    take_while(crate::util::is_ascii_indent).parse(input)
 }
 
 pub fn linebreak(input: &str) -> Result<(&str, &str), Error> {
-    take(|ch| ch == &'\n' || ch == &'\r' || ch == &'\u{000C}').parse(input)
-}
-
-pub fn linebreaks(input: &str) -> Result<(&str, &str), Error> {
-    take_while(|ch| ch == &'\n' || ch == &'\r' || ch == &'\u{000C}').parse(input)
+    take_while(crate::util::is_ascii_linebreak).parse(input)
 }
 
 pub fn whitespace(input: &str) -> Result<(&str, &str), Error> {
-    take(char::is_ascii_whitespace).parse(input)
-}
-
-pub fn whitespaces(input: &str) -> Result<(&str, &str), Error> {
     take_while(char::is_ascii_whitespace).parse(input)
 }
 
@@ -125,71 +76,55 @@ mod tests {
         );
         assert_eq!(parse("hello", sequence("hello")), Ok(("hello", "")));
         assert_eq!(parse("hello$", sequence("hello")), Ok(("hello", "$")));
+        assert_eq!(parse("hello", sequence("")), Ok(("", "hello")));
     }
 
     #[test]
     fn test_digit() {
         for ch in "0123456789".chars() {
-            assert_eq!(parse(&format!("{}", ch), digit), Ok((&*ch.to_string(), "")));
-        }
-
-        assert_eq!(parse("", digit), Err(Error::incomplete()));
-        assert_eq!(parse("$", digit), Err(Error::unexpected('$')));
-        assert_eq!(parse("a", digit), Err(Error::unexpected('a')));
-        assert_eq!(parse("Z", digit), Err(Error::unexpected('Z')));
-    }
-
-    #[test]
-    fn test_digits() {
-        for ch in "0123456789".chars() {
+            assert_eq!(parse(&ch.to_string(), decimal), Ok((&*ch.to_string(), "")));
             assert_eq!(
-                parse(&format!("{}", ch), digits),
-                Ok((&*ch.to_string(), ""))
+                parse(&(ch.to_string() + "$"), decimal),
+                Ok((&*ch.to_string(), "$"))
             );
         }
 
-        assert_eq!(parse("", digits), Err(Error::incomplete()));
-        assert_eq!(parse("$", digits), Err(Error::unexpected('$')));
-        assert_eq!(parse("a", digits), Err(Error::unexpected('a')));
-        assert_eq!(parse("Z", digits), Err(Error::unexpected('Z')));
-        assert_eq!(parse("0123456789", digits), Ok(("0123456789", "")));
-        assert_eq!(parse("0123456789$", digits), Ok(("0123456789", "$")));
+        for ch in "$aZ\n".chars() {
+            assert_eq!(parse(&ch.to_string(), decimal), Err(Error::unexpected(ch)));
+        }
+
+        assert_eq!(parse("", decimal), Err(Error::incomplete()));
+        assert_eq!(parse("0123456789", decimal), Ok(("0123456789", "")));
+        assert_eq!(parse("0123456789$", decimal), Ok(("0123456789", "$")));
     }
 
     #[test]
     fn test_hexdigit() {
         for ch in "0123456789abcdefABCDEF".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), hexdigit),
+                parse(&ch.to_string(), hexadecimal),
                 Ok((&*ch.to_string(), ""))
             );
-        }
-
-        assert_eq!(parse("", hexdigit), Err(Error::incomplete()));
-        assert_eq!(parse("$", hexdigit), Err(Error::unexpected('$')));
-        assert_eq!(parse("g", hexdigit), Err(Error::unexpected('g')));
-        assert_eq!(parse("Z", hexdigit), Err(Error::unexpected('Z')));
-    }
-
-    #[test]
-    fn test_hexdigits() {
-        for ch in "0123456789abcdefABCDEF".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), hexdigits),
-                Ok((&*ch.to_string(), ""))
+                parse(&(ch.to_string() + "$"), hexadecimal),
+                Ok((&*ch.to_string(), "$"))
             );
         }
 
-        assert_eq!(parse("", hexdigits), Err(Error::incomplete()));
-        assert_eq!(parse("$", hexdigits), Err(Error::unexpected('$')));
-        assert_eq!(parse("g", hexdigits), Err(Error::unexpected('g')));
-        assert_eq!(parse("Z", hexdigits), Err(Error::unexpected('Z')));
+        for ch in "$gZ\n".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), hexadecimal),
+                Err(Error::unexpected(ch))
+            );
+        }
+
+        assert_eq!(parse("", hexadecimal), Err(Error::incomplete()));
         assert_eq!(
-            parse("0123456789abcdefABCDEF", hexdigits),
+            parse("0123456789abcdefABCDEF", hexadecimal),
             Ok(("0123456789abcdefABCDEF", ""))
         );
         assert_eq!(
-            parse("0123456789abcdefABCDEF$", hexdigits),
+            parse("0123456789abcdefABCDEF$", hexadecimal),
             Ok(("0123456789abcdefABCDEF", "$"))
         );
     }
@@ -198,39 +133,34 @@ mod tests {
     fn test_alphabetic() {
         for ch in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), alphabetic),
+                parse(&ch.to_string(), alphabetic),
                 Ok((&*ch.to_string(), ""))
+            );
+            assert_eq!(
+                parse(&(ch.to_string() + "$"), alphabetic),
+                Ok((&*ch.to_string(), "$"))
+            );
+        }
+
+        for ch in "$0 \n".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), alphabetic),
+                Err(Error::unexpected(ch))
             );
         }
 
         assert_eq!(parse("", alphabetic), Err(Error::incomplete()));
-        assert_eq!(parse("$", alphabetic), Err(Error::unexpected('$')));
-        assert_eq!(parse("0", alphabetic), Err(Error::unexpected('0')));
-    }
-
-    #[test]
-    fn test_alphabetics() {
-        for ch in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
-            assert_eq!(
-                parse(&format!("{}", ch), alphabetics),
-                Ok((&*ch.to_string(), ""))
-            );
-        }
-
-        assert_eq!(parse("", alphabetics), Err(Error::incomplete()));
-        assert_eq!(parse("$", alphabetics), Err(Error::unexpected('$')));
-        assert_eq!(parse("0", alphabetics), Err(Error::unexpected('0')));
         assert_eq!(
             parse(
                 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
-                alphabetics
+                alphabetic
             ),
             Ok(("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", ""))
         );
         assert_eq!(
             parse(
                 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$",
-                alphabetics
+                alphabetic
             ),
             Ok(("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", "$"))
         );
@@ -240,30 +170,27 @@ mod tests {
     fn test_alphanumeric() {
         for ch in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), alphanumeric),
+                parse(&ch.to_string(), alphanumeric),
                 Ok((&*ch.to_string(), ""))
+            );
+            assert_eq!(
+                parse(&(ch.to_string() + "$"), alphanumeric),
+                Ok((&*ch.to_string(), "$"))
+            );
+        }
+
+        for ch in "$ \n".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), alphanumeric),
+                Err(Error::unexpected(ch))
             );
         }
 
         assert_eq!(parse("", alphanumeric), Err(Error::incomplete()));
-        assert_eq!(parse("$", alphanumeric), Err(Error::unexpected('$')));
-    }
-
-    #[test]
-    fn test_alphanumerics() {
-        for ch in "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
-            assert_eq!(
-                parse(&format!("{}", ch), alphanumerics),
-                Ok((&*ch.to_string(), ""))
-            );
-        }
-
-        assert_eq!(parse("", alphanumerics), Err(Error::incomplete()));
-        assert_eq!(parse("$", alphanumerics), Err(Error::unexpected('$')));
         assert_eq!(
             parse(
                 "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
-                alphanumerics
+                alphanumeric
             ),
             Ok((
                 "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -273,7 +200,7 @@ mod tests {
         assert_eq!(
             parse(
                 "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$",
-                alphanumerics
+                alphanumeric
             ),
             Ok((
                 "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -286,46 +213,29 @@ mod tests {
     fn test_lowercase() {
         for ch in "abcdefghijklmnopqrstuvwxyz".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), lowercase),
+                parse(&ch.to_string(), lowercase),
                 Ok((&*ch.to_string(), ""))
+            );
+            assert_eq!(
+                parse(&(ch.to_string() + "$"), lowercase),
+                Ok((&*ch.to_string(), "$"))
             );
         }
 
-        for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
+        for ch in "$ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), lowercase),
+                parse(&ch.to_string(), lowercase),
                 Err(Error::unexpected(ch))
             );
         }
 
         assert_eq!(parse("", lowercase), Err(Error::incomplete()));
-        assert_eq!(parse("$", lowercase), Err(Error::unexpected('$')));
-    }
-
-    #[test]
-    fn test_lowercases() {
-        for ch in "abcdefghijklmnopqrstuvwxyz".chars() {
-            assert_eq!(
-                parse(&format!("{}", ch), lowercases),
-                Ok((&*ch.to_string(), ""))
-            );
-        }
-
-        for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
-            assert_eq!(
-                parse(&format!("{}", ch), lowercases),
-                Err(Error::unexpected(ch))
-            );
-        }
-
-        assert_eq!(parse("", lowercases), Err(Error::incomplete()));
-        assert_eq!(parse("$", lowercases), Err(Error::unexpected('$')));
         assert_eq!(
-            parse("abcdefghijklmnopqrstuvwxyz", alphanumerics),
+            parse("abcdefghijklmnopqrstuvwxyz", lowercase),
             Ok(("abcdefghijklmnopqrstuvwxyz", ""))
         );
         assert_eq!(
-            parse("abcdefghijklmnopqrstuvwxyz$", alphanumerics),
+            parse("abcdefghijklmnopqrstuvwxyz$", lowercase),
             Ok(("abcdefghijklmnopqrstuvwxyz", "$"))
         );
     }
@@ -334,153 +244,104 @@ mod tests {
     fn test_uppercase() {
         for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), uppercase),
+                parse(&ch.to_string(), uppercase),
                 Ok((&*ch.to_string(), ""))
+            );
+            assert_eq!(
+                parse(&(ch.to_string() + "$"), uppercase),
+                Ok((&*ch.to_string(), "$"))
             );
         }
 
-        for ch in "abcdefghijklmnopqrstuvwxyz".chars() {
+        for ch in "$abcdefghijklmnopqrstuvwxyz".chars() {
             assert_eq!(
-                parse(&format!("{}", ch), uppercase),
+                parse(&ch.to_string(), uppercase),
                 Err(Error::unexpected(ch))
             );
         }
 
         assert_eq!(parse("", uppercase), Err(Error::incomplete()));
-        assert_eq!(parse("$", uppercase), Err(Error::unexpected('$')));
-    }
-
-    #[test]
-    fn test_uppercases() {
-        for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
-            assert_eq!(
-                parse(&format!("{}", ch), uppercases),
-                Ok((&*ch.to_string(), ""))
-            );
-        }
-
-        for ch in "abcdefghijklmnopqrstuvwxyz".chars() {
-            assert_eq!(
-                parse(&format!("{}", ch), uppercases),
-                Err(Error::unexpected(ch))
-            );
-        }
-
-        assert_eq!(parse("", uppercases), Err(Error::incomplete()));
-        assert_eq!(parse("$", uppercases), Err(Error::unexpected('$')));
         assert_eq!(
-            parse("ABCDEFGHIJKLMNOPQRSTUVWXYZ", alphanumerics),
+            parse("ABCDEFGHIJKLMNOPQRSTUVWXYZ", uppercase),
             Ok(("ABCDEFGHIJKLMNOPQRSTUVWXYZ", ""))
         );
         assert_eq!(
-            parse("ABCDEFGHIJKLMNOPQRSTUVWXYZ$", alphanumerics),
+            parse("ABCDEFGHIJKLMNOPQRSTUVWXYZ$", uppercase),
             Ok(("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "$"))
         );
     }
 
     #[test]
-    fn test_space() {
-        assert_eq!(parse("", space), Err(Error::incomplete()));
-        assert_eq!(parse("$", space), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", space), Err(Error::unexpected('\n')));
-        assert_eq!(parse("\t", space), Err(Error::unexpected('\t')));
-        assert_eq!(parse(" ", space), Ok((" ", "")));
-    }
-
-    #[test]
-    fn test_spaces() {
-        assert_eq!(parse("", spaces), Err(Error::incomplete()));
-        assert_eq!(parse("$", spaces), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", spaces), Err(Error::unexpected('\n')));
-        assert_eq!(parse("\t", spaces), Err(Error::unexpected('\t')));
-        assert_eq!(parse(" ", spaces), Ok((" ", "")));
-        assert_eq!(parse("   ", spaces), Ok(("   ", "")));
-    }
-
-    #[test]
-    fn test_tab() {
-        assert_eq!(parse("", tab), Err(Error::incomplete()));
-        assert_eq!(parse("$", tab), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", tab), Err(Error::unexpected('\n')));
-        assert_eq!(parse(" ", tab), Err(Error::unexpected(' ')));
-        assert_eq!(parse("\t", tab), Ok(("\t", "")));
-    }
-
-    #[test]
-    fn test_tabs() {
-        assert_eq!(parse("", tabs), Err(Error::incomplete()));
-        assert_eq!(parse("$", tabs), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", tabs), Err(Error::unexpected('\n')));
-        assert_eq!(parse(" ", tabs), Err(Error::unexpected(' ')));
-        assert_eq!(parse("\t", tabs), Ok(("\t", "")));
-        assert_eq!(parse("\t\t\t", tabs), Ok(("\t\t\t", "")));
-    }
-
-    #[test]
     fn test_indent() {
-        assert_eq!(parse("", indent), Err(Error::incomplete()));
-        assert_eq!(parse("$", indent), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", indent), Err(Error::unexpected('\n')));
-        assert_eq!(parse("\t", indent), Ok(("\t", "")));
-        assert_eq!(parse(" ", indent), Ok((" ", "")));
-    }
+        for ch in " \t".chars() {
+            assert_eq!(parse(&ch.to_string(), indent), Ok((&*ch.to_string(), "")));
+            assert_eq!(
+                parse(&(ch.to_string() + "$"), indent),
+                Ok((&*ch.to_string(), "$"))
+            );
+        }
 
-    #[test]
-    fn test_indents() {
-        assert_eq!(parse("", indents), Err(Error::incomplete()));
-        assert_eq!(parse("$", indents), Err(Error::unexpected('$')));
-        assert_eq!(parse("\n", indents), Err(Error::unexpected('\n')));
-        assert_eq!(parse("\t", indents), Ok(("\t", "")));
-        assert_eq!(parse(" ", indents), Ok((" ", "")));
-        assert_eq!(parse(" \t \t ", indents), Ok((" \t \t ", "")));
+        for ch in "$\n".chars() {
+            assert_eq!(parse(&ch.to_string(), indent), Err(Error::unexpected(ch)));
+        }
+
+        assert_eq!(parse("", indent), Err(Error::incomplete()));
+        assert_eq!(parse(" \t \t ", indent), Ok((" \t \t ", "")));
     }
 
     #[test]
     fn test_linebreak() {
-        assert_eq!(parse("", linebreak), Err(Error::incomplete()));
-        assert_eq!(parse("$", linebreak), Err(Error::unexpected('$')));
-        assert_eq!(parse(" ", linebreak), Err(Error::unexpected(' ')));
-        assert_eq!(parse("\t", linebreak), Err(Error::unexpected('\t')));
-        assert_eq!(parse("\n", linebreak), Ok(("\n", "")));
-        assert_eq!(parse("\r", linebreak), Ok(("\r", "")));
-        assert_eq!(parse("\u{000C}", linebreak), Ok(("\u{000C}", "")));
-    }
+        for ch in "\n\r\u{000C}".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), linebreak),
+                Ok((&*ch.to_string(), ""))
+            );
+            assert_eq!(
+                parse(&(ch.to_string() + "$"), linebreak),
+                Ok((&*ch.to_string(), "$"))
+            );
+        }
 
-    #[test]
-    fn test_linebreaks() {
-        assert_eq!(parse("", linebreaks), Err(Error::incomplete()));
-        assert_eq!(parse("$", linebreaks), Err(Error::unexpected('$')));
-        assert_eq!(parse(" ", linebreaks), Err(Error::unexpected(' ')));
-        assert_eq!(parse("\t", linebreaks), Err(Error::unexpected('\t')));
-        assert_eq!(parse("\n", linebreaks), Ok(("\n", "")));
-        assert_eq!(parse("\r", linebreaks), Ok(("\r", "")));
-        assert_eq!(parse("\u{000C}", linebreaks), Ok(("\u{000C}", "")));
-        assert_eq!(parse("\n\r\u{000C}", linebreaks), Ok(("\n\r\u{000C}", "")));
+        for ch in "$ \t".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), linebreak),
+                Err(Error::unexpected(ch))
+            );
+        }
+
+        assert_eq!(parse("", linebreak), Err(Error::incomplete()));
+        assert_eq!(parse("\n\r\u{000C}", linebreak), Ok(("\n\r\u{000C}", "")));
+        assert_eq!(parse("\n\r\u{000C}$", linebreak), Ok(("\n\r\u{000C}", "$")));
     }
 
     #[test]
     fn test_whitespace() {
-        assert_eq!(parse("", whitespace), Err(Error::incomplete()));
-        assert_eq!(parse("$", whitespace), Err(Error::unexpected('$')));
-        assert_eq!(parse(" ", whitespace), Ok((" ", "")));
-        assert_eq!(parse("\t", whitespace), Ok(("\t", "")));
-        assert_eq!(parse("\n", whitespace), Ok(("\n", "")));
-        assert_eq!(parse("\r", whitespace), Ok(("\r", "")));
-        assert_eq!(parse("\u{000C}", whitespace), Ok(("\u{000C}", "")));
-    }
+        for ch in " \t\n\r\u{000C}".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), whitespace),
+                Ok((&*ch.to_string(), ""))
+            );
+            assert_eq!(
+                parse(&(ch.to_string() + "$"), whitespace),
+                Ok((&*ch.to_string(), "$"))
+            );
+        }
 
-    #[test]
-    fn test_whitespaces() {
-        assert_eq!(parse("", whitespaces), Err(Error::incomplete()));
-        assert_eq!(parse("$", whitespaces), Err(Error::unexpected('$')));
-        assert_eq!(parse(" ", whitespaces), Ok((" ", "")));
-        assert_eq!(parse("\t", whitespaces), Ok(("\t", "")));
-        assert_eq!(parse("\n", whitespaces), Ok(("\n", "")));
-        assert_eq!(parse("\r", whitespaces), Ok(("\r", "")));
-        assert_eq!(parse("\u{000C}", whitespaces), Ok(("\u{000C}", "")));
+        for ch in "$a".chars() {
+            assert_eq!(
+                parse(&ch.to_string(), whitespace),
+                Err(Error::unexpected(ch))
+            );
+        }
+
+        assert_eq!(parse("", whitespace), Err(Error::incomplete()));
         assert_eq!(
-            parse(" \t\n\r\u{000C}", whitespaces),
+            parse(" \t\n\r\u{000C}", whitespace),
             Ok((" \t\n\r\u{000C}", ""))
+        );
+        assert_eq!(
+            parse(" \t\n\r\u{000C}$", whitespace),
+            Ok((" \t\n\r\u{000C}", "$"))
         );
     }
 }

--- a/crates/brace-parser/src/util.rs
+++ b/crates/brace-parser/src/util.rs
@@ -1,0 +1,15 @@
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub fn is_ascii_linebreak(ch: &char) -> bool {
+    match *ch as u8 {
+        b'\n' | b'\r' | b'\x0C' => true,
+        _ => false,
+    }
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub fn is_ascii_indent(ch: &char) -> bool {
+    match *ch as u8 {
+        b' ' | b'\t' => true,
+        _ => false,
+    }
+}


### PR DESCRIPTION
This refactors the character and sequence functionality with three core changes: renaming the _digit_ and _hexdigit_ methods, eliminating the single character sequences and removing the _space_ and _tab_ methods in favour of using the corresponding character. Also included are changes in the sequence matcher, improvements to the whitespace matching and simplified tests.