### PR TITLE
Add any character and sequence parsers

### DIFF
--- a/crates/brace-parser/src/character.rs
+++ b/crates/brace-parser/src/character.rs
@@ -129,6 +129,8 @@ mod tests {
             assert_eq!(parse(&ch.to_string(), any), Ok((ch, "")));
             assert_eq!(parse(&(ch.to_string() + "$"), any), Ok((ch, "$")));
         }
+
+        assert_eq!(parse("", any), Err(Error::incomplete()));
     }
 
     #[test]
@@ -148,6 +150,8 @@ mod tests {
                 Ok((ch, "$"))
             );
         }
+
+        assert_eq!(parse("", Character::Any), Err(Error::incomplete()));
     }
 
     #[test]

--- a/crates/brace-parser/src/sequence.rs
+++ b/crates/brace-parser/src/sequence.rs
@@ -131,6 +131,8 @@ mod tests {
                 Ok((&*(ch.to_string() + "$"), ""))
             );
         }
+
+        assert_eq!(parse("", any), Err(Error::incomplete()));
     }
 
     #[test]
@@ -156,6 +158,8 @@ mod tests {
                 Ok((&*(ch.to_string() + "$"), ""))
             );
         }
+
+        assert_eq!(parse("", Sequence::Any), Err(Error::incomplete()));
     }
 
     #[test]


### PR DESCRIPTION
This adds parsers that take any character or any sequence of characters. The latter is intended to be used only at the end of an input due to it being greedy.