### PR TITLE
Refactor string slice parser lifetime

### DIFF
--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -25,10 +25,7 @@ impl<'a> Parser<'a, char> for char {
     }
 }
 
-impl<'a, 'b> Parser<'a, &'b str> for &'b str
-where
-    'a: 'b,
-{
+impl<'a, 'b> Parser<'a, &'a str> for &'b str {
     fn parse(&self, input: &'a str) -> Result<(&'a str, &'a str), Error> {
         self::sequence::sequence(self).parse(input)
     }

--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -29,7 +29,7 @@ impl<'a, 'b> Parser<'a, &'b str> for &'b str
 where
     'a: 'b,
 {
-    fn parse(&self, input: &'a str) -> Result<(&'b str, &'a str), Error> {
+    fn parse(&self, input: &'a str) -> Result<(&'a str, &'a str), Error> {
         self::sequence::sequence(self).parse(input)
     }
 }


### PR DESCRIPTION
A previous change in the sequence method caused it to return a string slice of the input instead of the parser. This adjusts the lifetime to match the change.