### PR TITLE
Add support for unit type parsers

### DIFF
--- a/crates/brace-parser/src/combinator.rs
+++ b/crates/brace-parser/src/combinator.rs
@@ -414,6 +414,8 @@ mod tests {
             parse("hello universe!", series(vec!["hello", " ", "world"])),
             Err(Error::expect('w').but_found('u'))
         );
+        assert_eq!(parse("", series(())), Ok(((), "")));
+        assert_eq!(parse("hello", series(())), Ok(((), "hello")));
     }
 
     #[test]
@@ -437,5 +439,7 @@ mod tests {
             parse("d", branch(vec!["a", "b", "c"])),
             Err(Error::expect('c').but_found('d'))
         );
+        assert_eq!(parse("", branch(())), Ok(((), "")));
+        assert_eq!(parse("hello", branch(())), Ok(((), "hello")));
     }
 }

--- a/crates/brace-parser/src/combinator.rs
+++ b/crates/brace-parser/src/combinator.rs
@@ -91,6 +91,12 @@ pub trait Series<'a, O> {
     fn parse_series(&self, input: &'a str) -> Result<(O, &'a str), Error>;
 }
 
+impl<'a> Series<'a, ()> for () {
+    fn parse_series(&self, input: &'a str) -> Result<((), &'a str), Error> {
+        Ok(((), input))
+    }
+}
+
 impl<'a, T, O> Series<'a, Vec<O>> for Vec<T>
 where
     T: Parser<'a, O>,
@@ -119,6 +125,12 @@ pub fn series<'a, O>(series: impl Series<'a, O>) -> impl Parser<'a, O> {
 
 pub trait Branch<'a, O> {
     fn parse_branch(&self, input: &'a str) -> Result<(O, &'a str), Error>;
+}
+
+impl<'a> Branch<'a, ()> for () {
+    fn parse_branch(&self, input: &'a str) -> Result<((), &'a str), Error> {
+        Ok(((), input))
+    }
 }
 
 impl<'a, T, O> Branch<'a, O> for Vec<T>

--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -118,6 +118,12 @@ mod tests {
     }
 
     #[test]
+    fn test_parser_unit() {
+        assert_eq!(parse("", ()), Ok(((), "")));
+        assert_eq!(parse("hello", ()), Ok(((), "hello")));
+    }
+
+    #[test]
     fn test_parser_char() {
         assert_eq!(parse("", 'h'), Err(Error::expect('h').but_found_end()));
         assert_eq!(parse("$", 'h'), Err(Error::expect('h').but_found('$')));

--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -19,6 +19,12 @@ where
     }
 }
 
+impl<'a> Parser<'a, ()> for () {
+    fn parse(&self, input: &'a str) -> Result<((), &'a str), Error> {
+        Ok(((), input))
+    }
+}
+
 impl<'a> Parser<'a, char> for char {
     fn parse(&self, input: &'a str) -> Result<(char, &'a str), Error> {
         self::character::character(self).parse(input)


### PR DESCRIPTION
This adds support for unit type parsers that simply return the unit type and the given input.