### PR TITLE
Remove character and sequence parser methods

### DIFF
--- a/crates/brace-parser/src/character.rs
+++ b/crates/brace-parser/src/character.rs
@@ -1,19 +1,6 @@
-use std::borrow::Borrow;
 use std::fmt;
 
 use crate::parser::{take, Output, Parser};
-
-pub fn character<'a, T>(ch: T) -> impl Parser<'a, char>
-where
-    T: Borrow<char>,
-{
-    move |input| {
-        take(|character| character == *ch.borrow())
-            .parse(input)
-            .map(|(_, rem)| (*ch.borrow(), rem))
-            .map_err(|err| err.but_expect(*ch.borrow()))
-    }
-}
 
 pub fn any(input: &str) -> Output<char> {
     take(|_| true)
@@ -219,21 +206,6 @@ mod tests {
     use super::*;
     use crate::error::Error;
     use crate::parser::parse;
-
-    #[test]
-    fn test_character() {
-        assert_eq!(
-            parse("", character('h')),
-            Err(Error::expect('h').but_found_end())
-        );
-        assert_eq!(
-            parse("$", character('h')),
-            Err(Error::expect('h').but_found('$'))
-        );
-        assert_eq!(parse("h", character('h')), Ok(('h', "")));
-        assert_eq!(parse("hello", character('h')), Ok(('h', "ello")));
-        assert_eq!(parse("hello", character(&'h')), Ok(('h', "ello")));
-    }
 
     #[test]
     fn test_any() {

--- a/crates/brace-parser/src/sequence.rs
+++ b/crates/brace-parser/src/sequence.rs
@@ -1,32 +1,6 @@
 use std::fmt;
 
-use crate::error::Error;
 use crate::parser::{take_while, Output, Parser};
-
-pub fn sequence<'a, T>(sequence: T) -> impl Parser<'a, &'a str>
-where
-    T: AsRef<str>,
-{
-    move |input: &'a str| {
-        let mut iter = input.chars();
-        let mut pos = 0;
-
-        for ch in sequence.as_ref().chars() {
-            match iter.next() {
-                Some(character) => {
-                    if ch == character {
-                        pos += ch.len_utf8();
-                    } else {
-                        return Err(Error::expect(ch).but_found(character));
-                    }
-                }
-                None => return Err(Error::expect(ch).but_found_end()),
-            }
-        }
-
-        Ok(input.split_at(pos))
-    }
-}
 
 pub fn any(input: &str) -> Output<&str> {
     take_while(|_| true)
@@ -165,25 +139,6 @@ mod tests {
     use super::*;
     use crate::error::Error;
     use crate::parser::parse;
-
-    #[test]
-    fn test_sequence() {
-        assert_eq!(
-            parse("", sequence("hello")),
-            Err(Error::expect('h').but_found_end())
-        );
-        assert_eq!(
-            parse("h", sequence("hello")),
-            Err(Error::expect('e').but_found_end())
-        );
-        assert_eq!(
-            parse("help", sequence("hello")),
-            Err(Error::expect('l').but_found('p'))
-        );
-        assert_eq!(parse("hello", sequence("hello")), Ok(("hello", "")));
-        assert_eq!(parse("hello$", sequence("hello")), Ok(("hello", "$")));
-        assert_eq!(parse("hello", sequence("")), Ok(("", "hello")));
-    }
 
     #[test]
     fn test_any() {


### PR DESCRIPTION
This removes the explicit character and sequence parser methods in favour of using character and string literals.