### PR TITLE
Add unescape combinator

### DIFF
--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -7,7 +7,7 @@ pub mod sequence;
 pub mod prelude {
     pub use crate::combinator::branch::{branch, either, optional};
     pub use crate::combinator::series::{delimited, leading, list, pair, series, trailing, trio};
-    pub use crate::combinator::{consume, context, escaped, map, map_err, not};
+    pub use crate::combinator::{consume, context, escaped, map, map_err, not, unescape};
     pub use crate::error::{Error, Expect};
     pub use crate::parser::{parse, take, take_while, Output, Parser};
     pub use crate::{character, sequence};


### PR DESCRIPTION
This adds an unescape combinator that allows the specified escaped characters to be unescaped and optionally mapped.