### PR TITLE
Add pass and fail error states

### DIFF
--- a/crates/brace-parser/src/combinator/branch.rs
+++ b/crates/brace-parser/src/combinator/branch.rs
@@ -8,8 +8,8 @@ pub fn branch<'a, O>(branch: impl Branch<'a, O>) -> impl Parser<'a, O> {
 pub fn either<'a, O>(a: impl Parser<'a, O>, b: impl Parser<'a, O>) -> impl Parser<'a, O> {
     move |input| {
         a.parse(input).or_else(|err| match err {
-            Error::Soft(_) => b.parse(input),
-            Error::Hard(inner) => Err(Error::Hard(inner)),
+            Error::Pass(_) => b.parse(input),
+            Error::Fail(inner) => Err(Error::Fail(inner)),
         })
     }
 }
@@ -18,8 +18,8 @@ pub fn optional<'a, O>(parser: impl Parser<'a, O>) -> impl Parser<'a, Option<O>>
     move |input| match parser.parse(input) {
         Ok((out, rem)) => Ok((Some(out), rem)),
         Err(err) => match err {
-            Error::Soft(_) => Ok((None, input)),
-            Error::Hard(inner) => Err(Error::Hard(inner)),
+            Error::Pass(_) => Ok((None, input)),
+            Error::Fail(inner) => Err(Error::Fail(inner)),
         },
     }
 }
@@ -44,8 +44,8 @@ where
         for parser in self {
             match parser.parse(input) {
                 Ok(res) => return Ok(res),
-                Err(Error::Hard(inner)) => return Err(Error::Hard(inner)),
-                Err(Error::Soft(inner)) => out = Err(Error::Soft(inner)),
+                Err(Error::Fail(inner)) => return Err(Error::Fail(inner)),
+                Err(Error::Pass(inner)) => out = Err(Error::Pass(inner)),
             }
         }
 
@@ -89,7 +89,7 @@ macro_rules! impl_branch {
     (@inner $self:expr; $input:expr; $i:tt, $($idx:tt,)+) => {
         match $self.$i.parse($input) {
             Ok(res) => Ok(res),
-            Err(Error::Hard(inner)) => Err(Error::Hard(inner)),
+            Err(Error::Fail(inner)) => Err(Error::Fail(inner)),
             Err(_) => impl_branch!(@inner $self; $input; $($idx,)+),
         }
     };
@@ -116,11 +116,11 @@ mod tests {
     use crate::error::Error;
     use crate::parser::parse;
 
-    fn soft(_: &str) -> Output<&str> {
+    fn pass(_: &str) -> Output<&str> {
         Err(Error::expect('!'))
     }
 
-    fn hard(_: &str) -> Output<&str> {
+    fn fail(_: &str) -> Output<&str> {
         Err(Error::invalid())
     }
 
@@ -145,8 +145,8 @@ mod tests {
             parse("d", branch(vec!["a", "b", "c"])),
             Err(Error::expect('c').but_found('d'))
         );
-        assert_eq!(parse("a", branch(vec![soft])), Err(Error::expect('!')));
-        assert_eq!(parse("a", branch(vec![hard])), Err(Error::invalid()));
+        assert_eq!(parse("a", branch(vec![pass])), Err(Error::expect('!')));
+        assert_eq!(parse("a", branch(vec![fail])), Err(Error::invalid()));
         assert_eq!(parse("", branch(())), Ok(((), "")));
         assert_eq!(parse("hello", branch(())), Ok(((), "hello")));
         assert_eq!(
@@ -163,10 +163,10 @@ mod tests {
             parse("d", branch(("a", "b", "c"))),
             Err(Error::expect('c').but_found('d'))
         );
-        assert_eq!(parse("a", branch(("a", soft, "b"))), Ok(("a", "")));
-        assert_eq!(parse("b", branch(("a", soft, "b"))), Ok(("b", "")));
-        assert_eq!(parse("a", branch(("a", hard, "b"))), Ok(("a", "")));
-        assert_eq!(parse("b", branch(("a", hard, "b"))), Err(Error::invalid()));
+        assert_eq!(parse("a", branch(("a", pass, "b"))), Ok(("a", "")));
+        assert_eq!(parse("b", branch(("a", pass, "b"))), Ok(("b", "")));
+        assert_eq!(parse("a", branch(("a", fail, "b"))), Ok(("a", "")));
+        assert_eq!(parse("b", branch(("a", fail, "b"))), Err(Error::invalid()));
     }
 
     #[test]
@@ -190,8 +190,8 @@ mod tests {
             Err(Error::expect('o').but_found('t'))
         );
         assert_eq!(parse("onetwo", either("one", "two")), Ok(("one", "two")));
-        assert_eq!(parse("one", either(soft, "one")), Ok(("one", "")));
-        assert_eq!(parse("one", either(hard, "one")), Err(Error::invalid()));
+        assert_eq!(parse("one", either(pass, "one")), Ok(("one", "")));
+        assert_eq!(parse("one", either(fail, "one")), Err(Error::invalid()));
     }
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
             parse("hello world", optional("hello")),
             Ok((Some("hello"), " world"))
         );
-        assert_eq!(parse("", optional(soft)), Ok((None, "")));
-        assert_eq!(parse("", optional(hard)), Err(Error::invalid()));
+        assert_eq!(parse("", optional(pass)), Ok((None, "")));
+        assert_eq!(parse("", optional(fail)), Err(Error::invalid()));
     }
 }

--- a/crates/brace-parser/src/combinator/branch.rs
+++ b/crates/brace-parser/src/combinator/branch.rs
@@ -6,13 +6,21 @@ pub fn branch<'a, O>(branch: impl Branch<'a, O>) -> impl Parser<'a, O> {
 }
 
 pub fn either<'a, O>(a: impl Parser<'a, O>, b: impl Parser<'a, O>) -> impl Parser<'a, O> {
-    move |input| a.parse(input).or_else(|_| b.parse(input))
+    move |input| {
+        a.parse(input).or_else(|err| match err {
+            Error::Soft(_) => b.parse(input),
+            Error::Hard(inner) => Err(Error::Hard(inner)),
+        })
+    }
 }
 
 pub fn optional<'a, O>(parser: impl Parser<'a, O>) -> impl Parser<'a, Option<O>> {
     move |input| match parser.parse(input) {
         Ok((out, rem)) => Ok((Some(out), rem)),
-        Err(_) => Ok((None, input)),
+        Err(err) => match err {
+            Error::Soft(_) => Ok((None, input)),
+            Error::Hard(inner) => Err(Error::Hard(inner)),
+        },
     }
 }
 
@@ -34,10 +42,10 @@ where
         let mut out = Err(Error::invalid());
 
         for parser in self {
-            out = parser.parse(input);
-
-            if out.is_ok() {
-                return out;
+            match parser.parse(input) {
+                Ok(res) => return Ok(res),
+                Err(Error::Hard(inner)) => return Err(Error::Hard(inner)),
+                Err(Error::Soft(inner)) => out = Err(Error::Soft(inner)),
             }
         }
 
@@ -81,6 +89,7 @@ macro_rules! impl_branch {
     (@inner $self:expr; $input:expr; $i:tt, $($idx:tt,)+) => {
         match $self.$i.parse($input) {
             Ok(res) => Ok(res),
+            Err(Error::Hard(inner)) => Err(Error::Hard(inner)),
             Err(_) => impl_branch!(@inner $self; $input; $($idx,)+),
         }
     };
@@ -107,6 +116,14 @@ mod tests {
     use crate::error::Error;
     use crate::parser::parse;
 
+    fn soft(_: &str) -> Output<&str> {
+        Err(Error::expect('!'))
+    }
+
+    fn hard(_: &str) -> Output<&str> {
+        Err(Error::invalid())
+    }
+
     #[test]
     fn test_branch() {
         assert_eq!(parse("", branch(Vec::<&str>::new())), Err(Error::invalid()));
@@ -128,6 +145,8 @@ mod tests {
             parse("d", branch(vec!["a", "b", "c"])),
             Err(Error::expect('c').but_found('d'))
         );
+        assert_eq!(parse("a", branch(vec![soft])), Err(Error::expect('!')));
+        assert_eq!(parse("a", branch(vec![hard])), Err(Error::invalid()));
         assert_eq!(parse("", branch(())), Ok(((), "")));
         assert_eq!(parse("hello", branch(())), Ok(((), "hello")));
         assert_eq!(
@@ -144,6 +163,10 @@ mod tests {
             parse("d", branch(("a", "b", "c"))),
             Err(Error::expect('c').but_found('d'))
         );
+        assert_eq!(parse("a", branch(("a", soft, "b"))), Ok(("a", "")));
+        assert_eq!(parse("b", branch(("a", soft, "b"))), Ok(("b", "")));
+        assert_eq!(parse("a", branch(("a", hard, "b"))), Ok(("a", "")));
+        assert_eq!(parse("b", branch(("a", hard, "b"))), Err(Error::invalid()));
     }
 
     #[test]
@@ -167,6 +190,8 @@ mod tests {
             Err(Error::expect('o').but_found('t'))
         );
         assert_eq!(parse("onetwo", either("one", "two")), Ok(("one", "two")));
+        assert_eq!(parse("one", either(soft, "one")), Ok(("one", "")));
+        assert_eq!(parse("one", either(hard, "one")), Err(Error::invalid()));
     }
 
     #[test]
@@ -178,5 +203,7 @@ mod tests {
             parse("hello world", optional("hello")),
             Ok((Some("hello"), " world"))
         );
+        assert_eq!(parse("", optional(soft)), Ok((None, "")));
+        assert_eq!(parse("", optional(hard)), Err(Error::invalid()));
     }
 }

--- a/crates/brace-parser/src/error.rs
+++ b/crates/brace-parser/src/error.rs
@@ -90,6 +90,13 @@ impl Error {
         }
     }
 
+    pub fn into_pass(self) -> Self {
+        match self {
+            Self::Fail(inner) => Self::Pass(inner),
+            _ => self,
+        }
+    }
+
     pub fn is_fail(&self) -> bool {
         match self {
             Self::Fail(_) => true,
@@ -101,6 +108,13 @@ impl Error {
         match self {
             Self::Fail(inner) => Some(inner),
             _ => None,
+        }
+    }
+
+    pub fn into_fail(self) -> Self {
+        match self {
+            Self::Pass(inner) => Self::Fail(inner),
+            _ => self,
         }
     }
 }

--- a/crates/brace-parser/src/error.rs
+++ b/crates/brace-parser/src/error.rs
@@ -6,20 +6,20 @@ use crate::sequence::Sequence;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
-    Soft(InnerError),
-    Hard(InnerError),
+    Pass(InnerError),
+    Fail(InnerError),
 }
 
 impl Error {
     pub fn invalid() -> Self {
-        Self::Hard(InnerError(Some(Expect::Valid), None))
+        Self::Fail(InnerError(Some(Expect::Valid), None))
     }
 
     pub fn context<T>(ctx: T, err: Error) -> Self
     where
         T: Into<String>,
     {
-        Self::Soft(InnerError(
+        Self::Pass(InnerError(
             Some(Expect::Context(ctx.into(), Box::new(err))),
             None,
         ))
@@ -29,18 +29,18 @@ impl Error {
     where
         T: Into<Expect>,
     {
-        Self::Soft(InnerError(Some(expect.into()), None))
+        Self::Pass(InnerError(Some(expect.into()), None))
     }
 
     pub fn found<T>(found: T) -> Self
     where
         T: Into<Expect>,
     {
-        Self::Soft(InnerError(None, Some(found.into())))
+        Self::Pass(InnerError(None, Some(found.into())))
     }
 
     pub fn found_end() -> Self {
-        Self::Soft(InnerError(None, Some(Expect::End)))
+        Self::Pass(InnerError(None, Some(Expect::End)))
     }
 
     pub fn but_expect<T>(mut self, expect: T) -> Self
@@ -48,8 +48,8 @@ impl Error {
         T: Into<Expect>,
     {
         match self {
-            Self::Soft(ref mut inner) => inner.0 = Some(expect.into()),
-            Self::Hard(ref mut inner) => inner.0 = Some(expect.into()),
+            Self::Pass(ref mut inner) => inner.0 = Some(expect.into()),
+            Self::Fail(ref mut inner) => inner.0 = Some(expect.into()),
         }
 
         self
@@ -60,8 +60,8 @@ impl Error {
         T: Into<Expect>,
     {
         match self {
-            Self::Soft(ref mut inner) => inner.1 = Some(found.into()),
-            Self::Hard(ref mut inner) => inner.1 = Some(found.into()),
+            Self::Pass(ref mut inner) => inner.1 = Some(found.into()),
+            Self::Fail(ref mut inner) => inner.1 = Some(found.into()),
         }
 
         self
@@ -69,37 +69,37 @@ impl Error {
 
     pub fn but_found_end(mut self) -> Self {
         match self {
-            Self::Soft(ref mut inner) => inner.1 = Some(Expect::End),
-            Self::Hard(ref mut inner) => inner.1 = Some(Expect::End),
+            Self::Pass(ref mut inner) => inner.1 = Some(Expect::End),
+            Self::Fail(ref mut inner) => inner.1 = Some(Expect::End),
         }
 
         self
     }
 
-    pub fn is_soft(&self) -> bool {
+    pub fn is_pass(&self) -> bool {
         match self {
-            Self::Soft(_) => true,
+            Self::Pass(_) => true,
             _ => false,
         }
     }
 
-    pub fn as_soft(&self) -> Option<&InnerError> {
+    pub fn as_pass(&self) -> Option<&InnerError> {
         match self {
-            Self::Soft(inner) => Some(inner),
+            Self::Pass(inner) => Some(inner),
             _ => None,
         }
     }
 
-    pub fn is_hard(&self) -> bool {
+    pub fn is_fail(&self) -> bool {
         match self {
-            Self::Hard(_) => true,
+            Self::Fail(_) => true,
             _ => false,
         }
     }
 
-    pub fn as_hard(&self) -> Option<&InnerError> {
+    pub fn as_fail(&self) -> Option<&InnerError> {
         match self {
-            Self::Hard(inner) => Some(inner),
+            Self::Fail(inner) => Some(inner),
             _ => None,
         }
     }
@@ -110,8 +110,8 @@ impl error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Soft(inner) => write!(f, "{}", inner),
-            Self::Hard(inner) => write!(f, "{}", inner),
+            Self::Pass(inner) => write!(f, "{}", inner),
+            Self::Fail(inner) => write!(f, "{}", inner),
         }
     }
 }

--- a/crates/brace-parser/src/error.rs
+++ b/crates/brace-parser/src/error.rs
@@ -75,6 +75,34 @@ impl Error {
 
         self
     }
+
+    pub fn is_soft(&self) -> bool {
+        match self {
+            Self::Soft(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_soft(&self) -> Option<&InnerError> {
+        match self {
+            Self::Soft(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn is_hard(&self) -> bool {
+        match self {
+            Self::Hard(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_hard(&self) -> Option<&InnerError> {
+        match self {
+            Self::Hard(inner) => Some(inner),
+            _ => None,
+        }
+    }
 }
 
 impl error::Error for Error {}


### PR DESCRIPTION
This adds pass and fail error state variants to differentiate between errors that allow rolling back and errors that invalidate the entire input.