### PR TITLE
Export pass and fail error combinators in prelude

### DIFF
--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -7,7 +7,9 @@ pub mod sequence;
 pub mod prelude {
     pub use crate::combinator::branch::{branch, either, optional};
     pub use crate::combinator::series::{delimited, leading, list, pair, series, trailing, trio};
-    pub use crate::combinator::{consume, context, escaped, map, map_err, not, unescape};
+    pub use crate::combinator::{
+        consume, context, escaped, fail, map, map_err, not, pass, unescape,
+    };
     pub use crate::error::{Error, Expect};
     pub use crate::parser::{parse, take, take_while, Output, Parser};
     pub use crate::{character, sequence};


### PR DESCRIPTION
This exports the pass and fail combinators included in the previous commit via the prelude module.