### PR TITLE
Add peek combinator

### DIFF
--- a/crates/brace-parser/src/lib.rs
+++ b/crates/brace-parser/src/lib.rs
@@ -8,7 +8,7 @@ pub mod prelude {
     pub use crate::combinator::branch::{branch, either, optional};
     pub use crate::combinator::series::{delimited, leading, list, pair, series, trailing, trio};
     pub use crate::combinator::{
-        consume, context, escaped, fail, map, map_err, not, pass, unescape,
+        consume, context, escaped, fail, map, map_err, not, pass, peek, unescape,
     };
     pub use crate::error::{Error, Expect};
     pub use crate::parser::{parse, take, take_while, Output, Parser};


### PR DESCRIPTION
This adds a peek combinator which allows matching a parser without advancing the input.